### PR TITLE
fix: Generated header include relative path instead of component id

### DIFF
--- a/cutekit/builder.py
+++ b/cutekit/builder.py
@@ -394,8 +394,9 @@ def _globalHeaderHook(scope: TargetScope):
         # We can't generate an alias using symlinks because
         # because this will break #pragma once in some compilers.
         with open(aliasPath, "w") as f:
+            header = os.path.relpath(str(Path(c.path).parent), str(generatedDir))
             f.write("#pragma once\n")
-            f.write(f"#include <{c.id}/{os.path.basename(modPath)}>\n")
+            f.write(f'#include "{header}/{os.path.basename(modPath)}"\n')
 
 
 def build(


### PR DESCRIPTION
Description of the issue
========================

Let's imagine the following component structure
```
software/
├─ manifest.json -> A binary with id "software.cli" 
├─ lib/
│  ├─ manifest.json -> A lib with id "software"
│  ├─ mod.h
```

Afterwards we would like to include the lib like so: 
```C
#include <software>
```

But the alias generator will create a header file with the following content:
```C
#include <software/mod.h>
```
But as shown by the tree above, the mod file isn't in the "software" directory

The fix
=======

Since the compilation is ran at the root of the project, we can simply do a relative include like this:
```C
#include "../../../src/software/lib/mod.h"
```
The relative path is not hardcoded and is calculated by Python.