### PR TITLE
fix incompatible type for props cli arg

### DIFF
--- a/cutekit/builder.py
+++ b/cutekit/builder.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import platform
 from typing import Callable, Literal, TextIO, Union
 
-from . import cli, shell, rules, model, ninja, const, mixins, vt100
+from . import cli, shell, rules, model, ninja, const
 
 _logger = logging.getLogger(__name__)
 

--- a/cutekit/builder.py
+++ b/cutekit/builder.py
@@ -706,7 +706,7 @@ class RunArgs(BuildArgs, shell.DebugArgs, shell.ProfileArgs):
 def runCmd(args: RunArgs):
     if args.debug:
         args.mixins.append("debug")
-        args.props |= {"debug": "true"}
+        args.props |= {"debug": "True"}
 
     if args.component is None:
         args.component = "__main__"

--- a/cutekit/builder.py
+++ b/cutekit/builder.py
@@ -706,7 +706,7 @@ class RunArgs(BuildArgs, shell.DebugArgs, shell.ProfileArgs):
 def runCmd(args: RunArgs):
     if args.debug:
         args.mixins.append("debug")
-        args.props |= {"debug": True}
+        args.props |= {"debug": "true"}
 
     if args.component is None:
         args.component = "__main__"

--- a/cutekit/doc.py
+++ b/cutekit/doc.py
@@ -1,2 +1,0 @@
-from pathlib import Path
-from . import cli, shell

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -77,8 +77,8 @@ def test_deps_routing_with_bool_props():
     resolved = res.resolve("myapp")
     assert not resolved.enabled
     assert (
-        resolved.reason
-        == "Props missmatch for 'freestanding': Got 'True' but expected 'False'"
+        "Props missmatch for 'freestanding': Got 'True' but expected 'False'"
+        in str(resolved.reason)
     )
 
 

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -39,7 +39,7 @@ def test_deps_routing():
 
     t = model.Target("host", routing={"myembed": "myimplC"})
     res = model.Resolver(r, t)
-    assert res.resolve("myapp").reason == "No provider for 'myembed'"
+    assert "no provider for 'myembed'" in str(res.resolve("myapp").reason)
 
 
 def test_deps_routing_with_props():
@@ -64,7 +64,7 @@ def test_deps_routing_with_props():
     res = model.Resolver(r, t)
 
     resolved = res.resolve("myapp")
-    assert resolved.reason == "No provider for 'myembed'"
+    assert "no provider for 'myembed'" in str(resolved.reason)
 
 
 def test_deps_routing_with_bool_props():
@@ -102,4 +102,4 @@ def test_deps_routing_with_props_and_requires():
 
     t = model.Target("host", routing={"myembed": "myimplC"}, props={"myprop": "c"})
     res = model.Resolver(r, t)
-    assert res.resolve("myapp").reason == "No provider for 'myembed'"
+    assert "no provider for 'myembed'" in str(res.resolve("myapp").reason)


### PR DESCRIPTION
Resolves type checking error when running github actions
> cutekit/builder.py:709: error: Dict entry 0 has incompatible type "str": "bool"; expected "str": "str"  [dict-item]

Data type for `props` was updated in `commit`[e9d1428](https://github.com/cute-engineering/cutekit/commit/e9d14289543f789c67a70dfd4422012db1a51909) hence a need for this change