### PR TITLE
feat: add jexpr function to extract env variable

### DIFF
--- a/cutekit/shell.py
+++ b/cutekit/shell.py
@@ -384,6 +384,16 @@ def cloneDir(url: str, path: str, dest: str) -> str:
 
 LATEST_CACHE: dict[str, str] = {}
 
+@jexpr.exposed("shell.env")
+def env(varname: str, default: Optional[str] = None) -> Optional[str]:
+    """
+    Get an environment variable
+
+    varname: The name of the variable
+    default: The default value if the variable is not set
+    """
+    return os.environ.get(varname, default)
+
 
 @jexpr.exposed("shell.latest")
 def latest(cmd: str) -> str:


### PR DESCRIPTION
Little proposal to fix #27

This commit introduces a helper function for environment variable lookup. 
It can be used within targets, for example, in `host-any.json`, which now makes use of this new function.


```json
{
    "$schema": "https://schemas.cute.engineering/stable/cutekit.manifest.target.v1",
    "id": "host-{shell.uname().machine}",
    "type": "target",
    "props": {
        "toolchain": "clang",
        "arch": "{shell.uname().machine}",
        "sys": "{shell.uname().sysname}",
        "abi": "unknown",
        "bits": "unknown",
        "freestanding": false,
        "host": true,
        "sys-encoding": "utf8",
        "sys-line-ending": "lf",
        "sys-path-separator": "slash",
        "sys-terminal": "ansi"
    },
    "tools": {
        "cc": {
            "cmd": "{shell.env('CC', shell.latest('clang'))}"
        },
        "cxx": {
            "cmd": "{shell.env('CXX', shell.latest('clang++'))}"
        },
        "ld": {
            "cmd": "{shell.env('LD', shell.latest('clang++'))}"
        },
        "ar": {
            "cmd": "{shell.env('AR', shell.latest('llvm-ar'))}",
            "args": [
                "rcs"
            ]
        },
        "as": {
            "cmd": "nasm",
            "args": [
                "-f",
                "elf64"
            ]
        }
    }
}
```

@sleepy-monax what's your opinion on this?