### PR TITLE
Init system

### DIFF
--- a/cutekit/__init__.py
+++ b/cutekit/__init__.py
@@ -7,6 +7,7 @@ from . import (
     fmt,  # noqa: F401 this is imported for side effects
     package,  # noqa: F401 this is imported for side effects
     cli,
+    project,
     const,
     model,
     plugins,

--- a/cutekit/__init__.py
+++ b/cutekit/__init__.py
@@ -6,8 +6,8 @@ from . import (
     export,  # noqa: F401 this is imported for side effects
     fmt,  # noqa: F401 this is imported for side effects
     package,  # noqa: F401 this is imported for side effects
+    project, # noqa: F401 this is imported for side effects
     cli,
-    project,
     const,
     model,
     plugins,

--- a/cutekit/model.py
+++ b/cutekit/model.py
@@ -31,13 +31,15 @@ class Kind(StrEnum):
 
 
 # MARK: Manifest ---------------------------------------------------------------
+COMPONENT_SCHEMA = "https://schemas.cute.engineering/stable/cutekit.manifest.component.v1"
+PROJECT_SCHEMA = "https://schemas.cute.engineering/stable/cutekit.manifest.project.v1"
+TARGET_SCHEMA = "https://schemas.cute.engineering/stable/cutekit.manifest.target.v1"
 
 SUPPORTED_MANIFEST = [
-    "https://schemas.cute.engineering/stable/cutekit.manifest.component.v1",
-    "https://schemas.cute.engineering/stable/cutekit.manifest.project.v1",
-    "https://schemas.cute.engineering/stable/cutekit.manifest.target.v1",
+    COMPONENT_SCHEMA,
+    PROJECT_SCHEMA,
+    TARGET_SCHEMA
 ]
-
 
 def ensureSupportedManifest(manifest: Any, path: Path):
     """

--- a/cutekit/model.py
+++ b/cutekit/model.py
@@ -4,7 +4,7 @@ import logging
 import dataclasses as dt
 
 
-from enum import Enum
+from enum import StrEnum
 from typing import Any, Generator, Optional, Type, cast
 from pathlib import Path
 from dataclasses_json import DataClassJsonMixin
@@ -18,7 +18,7 @@ _logger = logging.getLogger(__name__)
 Props = dict[str, Any]
 
 
-class Kind(Enum):
+class Kind(StrEnum):
     """
     Enum representing the different kinds of manifests.
     """

--- a/cutekit/model.py
+++ b/cutekit/model.py
@@ -37,7 +37,9 @@ SUPPORTED_MANIFEST = [
     "https://schemas.cute.engineering/stable/cutekit.manifest.project.v1",
     "https://schemas.cute.engineering/stable/cutekit.manifest.target.v1",
 ]
-
+COMPONENT_SCHEMA = 0
+PROJECT_SCHEMA = 1
+TARGET_SCHEMA = 2
 
 def ensureSupportedManifest(manifest: Any, path: Path):
     """

--- a/cutekit/project.py
+++ b/cutekit/project.py
@@ -1,8 +1,8 @@
 from . import cli, model, vt100, shell
 from typing import Optional
-import os
 from pathlib import Path
 from enum import StrEnum
+import os
 
 
 class Suffix(StrEnum):
@@ -11,9 +11,9 @@ class Suffix(StrEnum):
 
 
 class InitArgs:
-    name: str = cli.operand("name", "Set the name of your project")
-    description: str = cli.arg(
-        None, "desc", "Set the description of your project", None)
+    name: str | None = cli.operand("name", "Set the name of your project")
+    description: str | None = cli.arg(
+        None, "desc", "Set the description of your project")
     kind: model.Kind = cli.arg(
         None, "kind", "Kind of the manifest", model.Kind.PROJECT)
     format: Suffix = cli.arg(
@@ -29,8 +29,8 @@ def init_manifest(args: InitArgs):
         type=args.kind,
     )
     filename: str = "project"
+    schema: str = model.PROJECT_SCHEMA
     project: Optional[model.Project] = model.Project.topmost()
-    schema: str = None
 
     """ Each type of kind """
     match model.KINDS[args.kind]:
@@ -44,7 +44,6 @@ def init_manifest(args: InitArgs):
             if model.KINDS[args.kind] == model.Component:
                 schema = model.COMPONENT_SCHEMA
                 manifest = model.Component(
-                    description=args.description,
                     **manifest.__dict__
                 )
                 if args.description:
@@ -78,9 +77,6 @@ def init_manifest(args: InitArgs):
             if project is not None:
                 raise RuntimeError("can't create subproject.")
 
-            schema = model.PROJECT_SCHEMA
-            filename = "project"
-
             if Path.cwd().name != args.name:
                 os.chdir(shell.mkdir(args.name))
 
@@ -112,7 +108,7 @@ def init_manifest(args: InitArgs):
                     import json
                     json.dump(manifest_data, f, indent=4)
                 case Suffix.TOML:
-                    import tomli_w
+                    import tomli_w # type: ignore
                     f.write(tomli_w.dumps(manifest_data))
     except Exception as e:
         vt100.error(f"can't create the file: {str(e.args)}")

--- a/cutekit/project.py
+++ b/cutekit/project.py
@@ -1,42 +1,67 @@
 from . import cli, model, vt100, shell
-import dataclasses, os
-from pathlib import Path
 from typing import Optional
+import os
+from pathlib import Path
 from enum import StrEnum
 
+
 class Suffix(StrEnum):
-    JSON="json"
-    TOML="toml"
+    JSON = "json"
+    TOML = "toml"
+
 
 class InitArgs:
     name: str = cli.operand("name", "Set the name of your project")
-    description: str = cli.arg(None,"desc", "Set the description of your project", None)
-    kind: model.Kind = cli.arg(None, "kind", "Kind of the manifest", model.Kind.PROJECT)
-    suffix: Suffix = cli.arg(None, "prefer", "Manifest format to use", Suffix.JSON)
+    description: str = cli.arg(
+        None, "desc", "Set the description of your project", None)
+    kind: model.Kind = cli.arg(
+        None, "kind", "Kind of the manifest", model.Kind.PROJECT)
+    format: Suffix = cli.arg(
+        None, "format", "Manifest format to use", Suffix.JSON)
 
-@cli.command("init", "Initialize your manifest.")
+
 def init_manifest(args: InitArgs):
-    if not vt100.ask(f"'{vt100.rgb(235, 111, 146) + args.name + vt100.RESET}' is the name of your project  ?"):
-        return 
-
-    filename = None
-    manifest: Optional[Manifest] = None
+    if args.name is None:
+        raise RuntimeError("Your manifest should be named")
 
     manifest = model.Manifest(
         id=args.name,
         type=args.kind,
     )
+    filename: str = "project"
+    project: Optional[model.Project] = model.Project.topmost()
+    schema: str = None
 
     """ Each type of kind """
     match model.KINDS[args.kind]:
         # Init a Component or a Target
         case model.Component | model.Target:
-            filename = "manifest"
-            """ Find the nearest Manifest """
-            project = model.Project.topmost()
             if project is None:
-                vt100.error(f"can't create '{args.kind}' without a project")
-                return
+                raise RuntimeError(
+                    f"can't create '{args.kind}' without a project")
+
+            filename = "manifest"
+            if model.KINDS[args.kind] == model.Component:
+                schema = model.COMPONENT_SCHEMA
+                manifest = model.Component(
+                    description=args.description,
+                    **manifest.__dict__
+                )
+                if args.description:
+                    manifest.description = args.description
+            else:
+                schema = model.TARGET_SCHEMA
+                manifest = model.Target(
+                    **manifest.__dict__
+                )
+
+            registry = model.Registry(project=project)
+            registry._append(project)
+            model.Registry._loadManifests(registry)
+
+            if (find := registry.manifests.get(args.name)) is not None:
+                raise RuntimeError(
+                    f" '{args.name}' manifest already exists at `{find.path}`")
 
             path = Path.cwd().relative_to(
                 os.path.dirname(project.path)
@@ -46,61 +71,61 @@ def init_manifest(args: InitArgs):
             if str(path) == project.dirname():
                 os.chdir(project.subpath("src"))
 
-            # Take the manifest from above.
-            while project.subpath("src") < path:
-                for suffix in model.Manifest.SUFFIXES:
-                    if Path(os.getcwd(), "manifest"+suffix).exists():
-                        break
-                path = path.parent
-
             os.chdir(shell.mkdir(f"{args.name}"))
 
-            if model.KINDS[args.kind] == model.Component:
-                manifest = model.Component(
-                    description=args.description,
-                    **manifest.__dict__
-                )
-                setattr(manifest, "$schema", model.SUPPORTED_MANIFEST[0])
-            else:
-                manifest = model.Target(
-                    **manifest.__dict__
-                )
-                setattr(manifest, "$schema", model.SUPPORTED_MANIFEST[2])
         # Init a Project.
         case model.Project:
-            if Path(os.getcwd()).name != args.name:
-                os.chdir(shell.mkdir(args.name))
+            if project is not None:
+                raise RuntimeError("can't create subproject.")
+
+            schema = model.PROJECT_SCHEMA
             filename = "project"
+
+            if Path.cwd().name != args.name:
+                os.chdir(shell.mkdir(args.name))
+
             if not Path("src").exists():
-                shell.mkdir("src") # Create src subdirectories
+                shell.mkdir("src")  # Create src subdirectories
+
             manifest = model.Project(
                 **manifest.__dict__
             )
-            setattr(manifest, "$schema", model.SUPPORTED_MANIFEST[1])
 
-    if hasattr(manifest, "description") and args.description:
-        manifest.description = args.description
+            if args.description:
+                manifest.description = args.description
 
-    filename += f".{args.suffix}"
+    # Avoid having manifests in different format
+    if model.Manifest.tryLoad(Path.cwd() / filename):
+        raise RuntimeError("Your Manifest already exist.")
+
+    filename += f".{args.format}"
     try:
-        if Path(os.getcwd(), filename).exists():
-            vt100.error(f"{filename} already exist.")
-            return
-
+        # Filter empty variable, and protected variables from Manifest.
         manifest_data = {
-            k:v for k,v in manifest.__dict__.items() if not k.startswith("_") and v
+            k: v for k, v in manifest.__dict__.items() if not k.startswith("_") and v
         }
+        manifest_data["$schema"] = schema
 
-        match args.suffix:
-            case Suffix.JSON:
-                import json
-                f = open(filename, "w")
-                json.dump(manifest_data, f, indent=4)
-            case Suffix.TOML:
-                import tomli_w
-                f = open(filename, "wb")
-                tomli_w.dump(manifest_data, f)
-    except _:
-        vt100.error("can't create the file")
+        with open(filename, "w", encoding="utf-8") as f:
+            match args.format:
+                case Suffix.JSON:
+                    import json
+                    json.dump(manifest_data, f, indent=4)
+                case Suffix.TOML:
+                    import tomli_w
+                    f.write(tomli_w.dumps(manifest_data))
+    except Exception as e:
+        vt100.error(f"can't create the file: {str(e.args)}")
+        # Remove manifest and the directories.
+        os.remove(Path.cwd() / filename)
+        if (Path.cwd() / "src").exists():
+            os.removedirs(Path.cwd() / "src")
+        os.removedirs(Path.cwd())
     finally:
         vt100.p("Manifest created.")
+    shell.restoreCwd()
+
+
+@cli.command("init", "Initialize your manifest.")
+def _(args: InitArgs):
+    init_manifest(args)

--- a/cutekit/project.py
+++ b/cutekit/project.py
@@ -1,42 +1,67 @@
 from . import cli, model, vt100, shell
-import dataclasses, os
-from pathlib import Path
 from typing import Optional
+import os
+from pathlib import Path
 from enum import StrEnum
 
+
 class Suffix(StrEnum):
-    JSON="json"
-    TOML="toml"
+    JSON = "json"
+    TOML = "toml"
+
 
 class InitArgs:
     name: str = cli.operand("name", "Set the name of your project")
-    description: str = cli.arg(None,"desc", "Set the description of your project", None)
-    kind: model.Kind = cli.arg(None, "kind", "Kind of the manifest", model.Kind.PROJECT)
-    suffix: Suffix = cli.arg(None, "prefer", "Manifest format to use", Suffix.JSON)
+    description: str = cli.arg(
+        None, "desc", "Set the description of your project", None)
+    kind: model.Kind = cli.arg(
+        None, "kind", "Kind of the manifest", model.Kind.PROJECT)
+    format: Suffix = cli.arg(
+        None, "format", "Manifest format to use", Suffix.JSON)
 
-@cli.command("init", "Initialize your manifest.")
+
 def init_manifest(args: InitArgs):
-    if not vt100.ask(f"'{vt100.rgb(235, 111, 146) + args.name + vt100.RESET}' is the name of your project  ?"):
-        return 
-
-    filename = None
-    manifest: Optional[Manifest] = None
+    if args.name is None:
+        raise RuntimeError("Your manifest should be named")
 
     manifest = model.Manifest(
         id=args.name,
         type=args.kind,
     )
+    filename: str = "project"
+    project: Optional[model.Project] = model.Project.topmost()
+    schema: str = None
 
     """ Each type of kind """
     match model.KINDS[args.kind]:
         # Init a Component or a Target
         case model.Component | model.Target:
-            filename = "manifest"
-            """ Find the nearest Manifest """
-            project = model.Project.topmost()
             if project is None:
-                vt100.error(f"can't create '{args.kind}' without a project")
-                return
+                raise RuntimeError(
+                    f"can't create '{args.kind}' without a project")
+
+            filename = "manifest"
+            if model.KINDS[args.kind] == model.Component:
+                schema = model.SUPPORTED_MANIFEST[model.COMPONENT_SCHEMA]
+                manifest = model.Component(
+                    description=args.description,
+                    **manifest.__dict__
+                )
+                if args.description:
+                    manifest.description = args.description
+            else:
+                schema = model.SUPPORTED_MANIFEST[model.TARGET_SCHEMA]
+                manifest = model.Target(
+                    **manifest.__dict__
+                )
+
+            registry = model.Registry(project=project)
+            registry._append(project)
+            model.Registry._loadManifests(registry)
+
+            if (find := registry.manifests.get(args.name)) is not None:
+                raise RuntimeError(
+                    f" '{args.name}' manifest already exists at `{find.path}`")
 
             path = Path.cwd().relative_to(
                 os.path.dirname(project.path)
@@ -46,61 +71,61 @@ def init_manifest(args: InitArgs):
             if str(path) == project.dirname():
                 os.chdir(project.subpath("src"))
 
-            # Take the manifest from above.
-            while project.subpath("src") < path:
-                for suffix in model.Manifest.SUFFIXES:
-                    if Path(os.getcwd(), "manifest"+suffix).exists():
-                        break
-                path = path.parent
-
             os.chdir(shell.mkdir(f"{args.name}"))
 
-            if model.KINDS[args.kind] == model.Component:
-                manifest = model.Component(
-                    description=args.description,
-                    **manifest.__dict__
-                )
-                setattr(manifest, "$schema", model.SUPPORTED_MANIFEST[0])
-            else:
-                manifest = model.Target(
-                    **manifest.__dict__
-                )
-                setattr(manifest, "$schema", model.SUPPORTED_MANIFEST[2])
         # Init a Project.
         case model.Project:
-            if Path(os.getcwd()).name != args.name:
-                os.chdir(shell.mkdir(args.name))
+            if project is not None:
+                raise RuntimeError("can't create subproject.")
+
+            schema = model.SUPPORTED_MANIFEST[model.PROJECT_SCHEMA]
             filename = "project"
+
+            if Path.cwd().name != args.name:
+                os.chdir(shell.mkdir(args.name))
+
             if not Path("src").exists():
-                shell.mkdir("src") # Create src subdirectories
+                shell.mkdir("src")  # Create src subdirectories
+
             manifest = model.Project(
                 **manifest.__dict__
             )
-            setattr(manifest, "$schema", model.SUPPORTED_MANIFEST[1])
 
-    if hasattr(manifest, "description") and args.description:
-        manifest.description = args.description
+            if args.description:
+                manifest.description = args.description
 
-    filename += f".{args.suffix}"
+    # Avoid having manifests in different format
+    if model.Manifest.tryLoad(Path.cwd() / filename):
+        raise RuntimeError("Your Manifest already exist.")
+
+    filename += f".{args.format}"
     try:
-        if Path(os.getcwd(), filename).exists():
-            vt100.error(f"{filename} already exist.")
-            return
-
+        # Filter empty variable, and protected variables from Manifest.
         manifest_data = {
-            k:v for k,v in manifest.__dict__.items() if not k.startswith("_") and v
+            k: v for k, v in manifest.__dict__.items() if not k.startswith("_") and v
         }
+        manifest_data["$schema"] = schema
 
-        match args.suffix:
-            case Suffix.JSON:
-                import json
-                f = open(filename, "w")
-                json.dump(manifest_data, f, indent=4)
-            case Suffix.TOML:
-                import tomli_w
-                f = open(filename, "wb")
-                tomli_w.dump(manifest_data, f)
-    except _:
-        vt100.error("can't create the file")
+        with open(filename, "w", encoding="utf-8") as f:
+            match args.format:
+                case Suffix.JSON:
+                    import json
+                    json.dump(manifest_data, f, indent=4)
+                case Suffix.TOML:
+                    import tomli_w
+                    f.write(tomli_w.dumps(manifest_data))
+    except Exception as e:
+        vt100.error(f"can't create the file: {str(e.args)}")
+        # Remove manifest and the directories.
+        os.remove(Path.cwd() / filename)
+        if (Path.cwd() / "src").exists():
+            os.removedirs(Path.cwd() / "src")
+        os.removedirs(Path.cwd())
     finally:
         vt100.p("Manifest created.")
+    shell.restoreCwd()
+
+
+@cli.command("init", "Initialize your manifest.")
+def _(args: InitArgs):
+    init_manifest(args)

--- a/cutekit/project.py
+++ b/cutekit/project.py
@@ -11,8 +11,8 @@ class Suffix(StrEnum):
 
 
 class InitArgs:
-    name: str | None = cli.operand("name", "Set the name of your project")
-    description: str | None = cli.arg(
+    name: str = cli.operand("name", "Set the name of your project")
+    description: str = cli.arg(
         None, "desc", "Set the description of your project")
     kind: model.Kind = cli.arg(
         None, "kind", "Kind of the manifest", model.Kind.PROJECT)

--- a/cutekit/project.py
+++ b/cutekit/project.py
@@ -1,0 +1,106 @@
+from . import cli, model, vt100, shell
+import dataclasses, os
+from pathlib import Path
+from typing import Optional
+from enum import StrEnum
+
+class Suffix(StrEnum):
+    JSON="json"
+    TOML="toml"
+
+class InitArgs:
+    name: str = cli.operand("name", "Set the name of your project")
+    description: str = cli.arg(None,"desc", "Set the description of your project", None)
+    kind: model.Kind = cli.arg(None, "kind", "Kind of the manifest", model.Kind.PROJECT)
+    suffix: Suffix = cli.arg(None, "prefer", "Manifest format to use", Suffix.JSON)
+
+@cli.command("init", "Initialize your manifest.")
+def init_manifest(args: InitArgs):
+    if not vt100.ask(f"'{vt100.rgb(235, 111, 146) + args.name + vt100.RESET}' is the name of your project  ?"):
+        return 
+
+    filename = None
+    manifest: Optional[Manifest] = None
+
+    manifest = model.Manifest(
+        id=args.name,
+        type=args.kind,
+    )
+
+    """ Each type of kind """
+    match model.KINDS[args.kind]:
+        # Init a Component or a Target
+        case model.Component | model.Target:
+            filename = "manifest"
+            """ Find the nearest Manifest """
+            project = model.Project.topmost()
+            if project is None:
+                vt100.error(f"can't create '{args.kind}' without a project")
+                return
+
+            path = Path.cwd().relative_to(
+                os.path.dirname(project.path)
+            )
+
+            # If it's the root of the project
+            if str(path) == project.dirname():
+                os.chdir(project.subpath("src"))
+
+            # Take the manifest from above.
+            while project.subpath("src") < path:
+                for suffix in model.Manifest.SUFFIXES:
+                    if Path(os.getcwd(), "manifest"+suffix).exists():
+                        break
+                path = path.parent
+
+            os.chdir(shell.mkdir(f"{args.name}"))
+
+            if model.KINDS[args.kind] == model.Component:
+                manifest = model.Component(
+                    description=args.description,
+                    **manifest.__dict__
+                )
+                setattr(manifest, "$schema", model.SUPPORTED_MANIFEST[0])
+            else:
+                manifest = model.Target(
+                    **manifest.__dict__
+                )
+                setattr(manifest, "$schema", model.SUPPORTED_MANIFEST[2])
+        # Init a Project.
+        case model.Project:
+            if Path(os.getcwd()).name != args.name:
+                os.chdir(shell.mkdir(args.name))
+            filename = "project"
+            if not Path("src").exists():
+                shell.mkdir("src") # Create src subdirectories
+            manifest = model.Project(
+                **manifest.__dict__
+            )
+            setattr(manifest, "$schema", model.SUPPORTED_MANIFEST[1])
+
+    if hasattr(manifest, "description") and args.description:
+        manifest.description = args.description
+
+    filename += f".{args.suffix}"
+    try:
+        if Path(os.getcwd(), filename).exists():
+            vt100.error(f"{filename} already exist.")
+            return
+
+        manifest_data = {
+            k:v for k,v in manifest.__dict__.items() if not k.startswith("_") and v
+        }
+
+        match args.suffix:
+            case Suffix.JSON:
+                import json
+                f = open(filename, "w")
+                json.dump(manifest_data, f, indent=4)
+            case Suffix.TOML:
+                import tomli_w
+                f = open(filename, "wb")
+                tomli_w.dump(manifest_data, f)
+    except _:
+        vt100.error("can't create the file")
+    finally:
+        vt100.p("Manifest created.")

--- a/cutekit/requirements.txt
+++ b/cutekit/requirements.txt
@@ -1,2 +1,3 @@
 graphviz ~= 0.20.1
 dataclasses-json ~= 0.6.4
+tomli-w ~= 1.2.0

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,94 @@
+from pathlib import Path
+from cutekit import model, project, shell
+from typing import Optional
+from shutil import rmtree
+import os
+import pytest
+
+
+def check_tree(manifest_cwd: Path, args: project.InitArgs):
+    assert (manifest_cwd.exists())
+    if args.kind == model.Kind.PROJECT:
+        assert ((manifest_cwd / f"project.{args.format}").exists())
+        assert ((manifest_cwd / "src").exists())
+        assert (model.Project.tryLoad((manifest_cwd / "project")))
+    else:
+        assert ((manifest_cwd / f"manifest.{args.format}").exists())
+        assert (model.Project.tryLoad((manifest_cwd / "manifest")))
+
+
+def setup_args(
+        name: str,
+        kind: Optional[model.Kind] = None,
+        format: Optional[project.Suffix] = None
+) -> project.InitArgs:
+    args = project.InitArgs()
+    args.name = name
+    args.format = format or project.Suffix.JSON
+    args.kind = kind or model.Kind.PROJECT
+    args.description = "(No description)"
+    return args
+
+
+def test_sample_project():
+    args = setup_args("test_json_sample")
+    cwd = Path.cwd() / "tests"
+    os.chdir(cwd)
+    project_cwd = cwd / args.name
+    project.init_manifest(args)
+    # Check the project is correctly created
+    check_tree(project_cwd, args)
+    os.chdir(cwd)
+    # Avoid overwriting
+    pytest.raises(RuntimeError, project.init_manifest, args)
+    args.format = project.Suffix.TOML
+    # Avoid other manifest format creation when one is used.
+    pytest.raises(RuntimeError, project.init_manifest, args)
+    shell.restoreCwd()
+    rmtree(project_cwd)  # Remove the directories and his content
+
+
+def test_complex_project():
+    args = setup_args("test_complex_project")
+    cwd = Path.cwd() / "tests"
+    os.chdir(cwd)
+    project_cwd = cwd / args.name
+    project.init_manifest(args)
+    # Check the project is correctly created
+    check_tree(project_cwd, args)
+
+    # Create a lib component:
+    os.chdir(project_cwd)
+    args = setup_args("libcomplex", model.Kind.LIB)
+    libcomplex_cwd = project_cwd / "src" / args.name
+    project.init_manifest(args)
+    check_tree(libcomplex_cwd, args)
+
+    pytest.raises(RuntimeError, project.init_manifest, args)
+
+    # Try from src
+    os.chdir(project_cwd / "src")
+    args = setup_args("libc", model.Kind.LIB, project.Suffix.TOML)
+    project.init_manifest(args)
+    libc_cwd = project_cwd / "src" / args.name
+    check_tree(libc_cwd, args)
+
+    # Creating lib inside of src/libc
+    os.chdir(libc_cwd)
+    pytest.raises(RuntimeError, project.init_manifest, args)
+
+    # Creating shell directory
+    os.chdir(shell.mkdir("shell"))
+
+    # Create bash component
+    args = setup_args("bash", model.Kind.EXE)
+    shell_cwd = Path.cwd()
+    project.init_manifest(args)
+    check_tree(shell_cwd / args.name, args)
+
+    args.name = "libc"
+    pytest.raises(RuntimeError, project.init_manifest, args)
+    os.chdir(project_cwd)
+
+    shell.restoreCwd()
+    rmtree(project_cwd)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,96 @@
+from pathlib import Path
+from cutekit import model, project, shell
+from typing import Optional
+from shutil import rmtree
+import os
+import pytest
+
+
+def check_tree(manifest_cwd: Path, args: project.InitArgs):
+    assert (manifest_cwd.exists())
+    if args.kind == model.Kind.PROJECT:
+        assert ((manifest_cwd / f"project.{args.format}").exists())
+        assert ((manifest_cwd / "src").exists())
+        assert (model.Project.tryLoad((manifest_cwd / "project")))
+    else:
+        assert ((manifest_cwd / f"manifest.{args.format}").exists())
+        assert (model.Project.tryLoad((manifest_cwd / "manifest")))
+
+
+def setup_args(
+        name: str,
+        kind: Optional[model.Kind] = None,
+        format: Optional[project.Suffix] = None
+) -> project.InitArgs:
+    args = project.InitArgs()
+    args.name = name
+    args.format = format or project.Suffix.JSON
+    args.kind = kind or model.Kind.PROJECT
+    args.description = "(No description)"
+    return args
+
+
+def test_sample_project():
+    args = setup_args("test_json_sample")
+    cwd = Path.cwd() / "tests"
+    os.chdir(cwd)
+    project_cwd = cwd / args.name
+    project.init_manifest(args)
+    # Check the project is correctly created
+    check_tree(project_cwd, args)
+    os.chdir(cwd)
+    # Avoid overwriting
+    pytest.raises(RuntimeError, project.init_manifest, args)
+    args.format = project.Suffix.TOML
+    # Avoid other manifest format creation when one is used.
+    pytest.raises(RuntimeError, project.init_manifest, args)
+    shell.restoreCwd()
+    rmtree(project_cwd)  # Remove the directories and his content
+
+
+def test_complex_project():
+    args = setup_args("test_complex_project")
+    cwd = Path.cwd() / "tests"
+    os.chdir(cwd)
+    project_cwd = cwd / args.name
+    project.init_manifest(args)
+    # Check the project is correctly created
+    check_tree(project_cwd, args)
+
+    # Create a lib component:
+    os.chdir(project_cwd)
+    args = setup_args("libcomplex", model.Kind.LIB)
+    libcomplex_cwd = project_cwd / "src" / args.name
+    project.init_manifest(args)
+    check_tree(libcomplex_cwd, args)
+
+    pytest.raises(RuntimeError, project.init_manifest, args)
+
+    # Try from src
+    os.chdir(project_cwd / "src")
+    args = setup_args("libc", model.Kind.LIB, project.Suffix.TOML)
+    project.init_manifest(args)
+    libc_cwd = project_cwd / "src" / args.name
+    check_tree(libc_cwd, args)
+
+    # Creating lib inside of src/libc
+    os.chdir(libc_cwd)
+    pytest.raises(RuntimeError, project.init_manifest, args)
+
+    # Creating shell directory
+    os.chdir(shell.mkdir("shell"))
+
+    # Create bash component
+    args = setup_args("bash", model.Kind.EXE)
+    shell_cwd = Path.cwd()
+    project.init_manifest(args)
+    check_tree(shell_cwd / args.name, args)
+
+    args.name = "libc"
+    pytest.raises(RuntimeError, project.init_manifest, args)
+    os.chdir(project_cwd)
+
+    shell.exec(*["tree", project_cwd])
+
+    shell.restoreCwd()
+    rmtree(project_cwd)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -3,7 +3,7 @@ from cutekit import model, project, shell
 from typing import Optional
 from shutil import rmtree
 import os
-import pytest
+import pytest # type: ignore
 
 
 def check_tree(manifest_cwd: Path, args: project.InitArgs):


### PR DESCRIPTION
How `ck init <manifest name>` is designed:

Default args:
- description = (No description)
- suffix = json (over toml)
- kind = project

Double checking before the creation of the folder.

Rules:
- You can't `ck init` a component nor a target manifest outside of a project manifest.
- You can't overwrite the same manifest.
- `ck init` a component/target will be create at the most neighborhood manifest (in the worst scenario at the top of your project inside the src directories)

Cons:
- usage of `tomli_w` (a new package needed)
- usage of `__dict__` on Manifest (and his child) Class